### PR TITLE
[Feature] Add option to prune useless keys from target files based on source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This action generates localized strings for a given project based on the source 
 **optional**(default: `"%{(.*?)}"`) The pattern to use to identify the variables in the source files. **Use a regex group to capture the variable name**, like `"%{(.*?)}"` for instance.
 ### `file_type`
 **optional**(default: `yaml`) The file type of the source files.
+### `prune_useless_keys`
+**optional**(default: `true`) Whether to prune the keys that are not present in the source language files.
 
 
 ## Example usage
@@ -54,7 +56,8 @@ jobs:
         api_keys: ${{ secrets.DEEPL_API_KEY }}
         api_type: 'deepl'
         variable_pattern: '"%{(.*?)}"'
-        file_type: 'yaml'
+        file_type: 'yaml'$
+        prune_useless_keys: 'true'
     - name: Commit and push
       run: |
         git config --local user.email "auto-localize@github-actions.com"

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "The type of the translation API"
     required: true
     default: "deepl"
+  prune_useless_keys:
+    description: "Whether to prune keys that are not present in the source language"
+    required: false
+    default: "true"
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -45,3 +49,4 @@ runs:
     API_KEYS: ${{ inputs.api_keys }}
     FILE_TYPE: ${{ inputs.file_type }}
     API_TYPE: ${{ inputs.api_type }}
+    PRUNE_USELESS_KEYS: ${{ inputs.prune_useless_keys }}

--- a/src/files/base.py
+++ b/src/files/base.py
@@ -74,6 +74,25 @@ class BaseFile:
           missing_keys.append(current_key_path + [key])
     return missing_keys
 
+  @staticmethod
+  def prune_useless_keys(object: dict, model_object: dict) -> dict:
+    """
+    Prune useless keys from a dictionary based on a model object.
+
+    :param object: The dictionary to prune keys from.
+    :param model_object: The model object to use for pruning.
+    :return: The dictionary with the keys pruned.
+    """
+    pruned_data = {}
+    for key, value in object.items():
+      if key not in model_object:
+        continue
+      if type(value) == dict:
+        pruned_data[key] = BaseFile.prune_useless_keys(value, model_object[key])
+      else:
+        pruned_data[key] = value
+    return pruned_data
+
   # --- Protected methods ---
 
   @staticmethod

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ TARGET_FILES_DIRECTORY = os.environ["TARGET_FILES_DIRECTORY"]
 API_KEYS = os.environ["API_KEYS"].split(",")
 FILE_TYPE = os.environ["FILE_TYPE"]
 API_TYPE = os.environ["API_TYPE"]
+PRUNE_USELESS_KEYS = os.environ["PRUNE_USELESS_KEYS"].lower() == "true" if "PRUNE_USELESS_KEYS" in os.environ else False
 
 # --- Main script ---
 
@@ -52,4 +53,6 @@ for source_file in source_files:
         target_translation_data = target_translation_data.setdefault(key, {})
       target_translation_data[keys[-1]] = target_translation
     print(f"[{source_file} - {target_language}] Writing translations to '{target_file}'")
+    if PRUNE_USELESS_KEYS:
+      target_data = file_class.prune_useless_keys(target_data, source_data)
     file_class.write(target_file, target_data)


### PR DESCRIPTION
This PR allows to prune useless keys from a dictionary based on a model object.

The idea behind that is to allow to remove useless keys from the target files if they are not present anymore in the source files.

I've tested it locally by running the script against some test translation files.